### PR TITLE
feat: productize homepage with live game status hub

### DIFF
--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -1,50 +1,47 @@
 /**
  * NextReset - Console Hub Design
- * Xbox-inspired dark theme with green accent
+ * Dark theme with console-hub styling
  */
 
 :root {
-  /* Backgrounds */
-  --bg0: #0b0f14;
-  /* page background */
-  --bg1: #0f1620;
-  /* subtle gradient top */
-  --panel: #121b26;
-  /* cards/panels */
-  --panel2: #0f1722;
-  /* deeper panels */
-  --border: rgba(255, 255, 255, .08);
+  /* === NEW VARIABLES (Plan Spec) === */
+  --bg-main: #0b0f14;
+  --bg-card: #111827;
+  --bg-card-muted: #0f172a;
 
-  /* Text */
-  --text: #e8eef6;
-  --muted: #9aa7b5;
+  --text-primary: #e5e7eb;
+  --text-secondary: #9ca3af;
+  --text-muted: #6b7280;
 
-  /* Accents */
-  --accent: #34d399;
-  /* xbox-ish green */
-  --accent2: #22c55e;
+  --accent-live: #22c55e;
+  --accent-stale: #eab308;
+  --accent-unavailable: #64748b;
+
+  --border-card: #1f2937;
+  --border-soft: #1e293b;
+
+  --shadow-card: 0 10px 30px rgba(0, 0, 0, 0.4);
+
+  --radius-card: 14px;
+  --radius-pill: 999px;
+
+  --font-main: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+
+  /* === LEGACY MAPPINGS (Temporary) === */
+  --bg0: var(--bg-main);
+  --bg1: var(--bg-card-muted);
+  --panel: var(--bg-card);
+  --panel2: var(--bg-card-muted);
+  --border: var(--border-card);
+  --text: var(--text-primary);
+  --muted: var(--text-muted);
+  --accent: var(--accent-live);
+  --accent2: var(--accent-live);
   --danger: #fb7185;
 
   /* Effects */
   --shadow: 0 12px 30px rgba(0, 0, 0, .45);
   --radius: 18px;
-}
-
-/* Light mode (system preference) */
-@media (prefers-color-scheme: light) {
-  :root {
-    --bg0: #f8fafc;
-    --bg1: #ffffff;
-    --panel: #ffffff;
-    --panel2: #f1f5f9;
-    --border: rgba(0, 0, 0, .08);
-    --text: #0f172a;
-    --muted: #475569;
-    --accent: #22c55e;
-    --accent2: #16a34a;
-    --danger: #e11d48;
-    --shadow: 0 12px 30px rgba(0, 0, 0, .08);
-  }
 }
 
 /* Base */
@@ -119,6 +116,29 @@ a {
 .nav a:hover {
   color: var(--text);
   transition: color .15s ease;
+}
+
+/* Trust Badges */
+.trust-badges {
+  display: flex;
+  gap: 10px;
+}
+
+.trust-badge {
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 4px 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-pill);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .trust-badges {
+    display: none;
+  }
 }
 
 /* Hero */
@@ -505,6 +525,114 @@ footer p {
   margin: 6px 0;
 }
 
+/* Status Badges */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.badge-live {
+  background: rgba(34, 197, 94, .15);
+  color: var(--accent-live);
+  border: 1px solid rgba(34, 197, 94, .3);
+}
+
+.badge-live::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-live);
+  animation: pulse 2s infinite;
+}
+
+.badge-stale {
+  background: rgba(234, 179, 8, .15);
+  color: var(--accent-stale);
+  border: 1px solid rgba(234, 179, 8, .3);
+}
+
+.badge-unavailable {
+  background: rgba(100, 116, 139, .15);
+  color: var(--accent-unavailable);
+  border: 1px solid rgba(100, 116, 139, .3);
+}
+
+@keyframes pulse {
+
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Card States */
+.card[data-state="unavailable"] {
+  opacity: 0.7;
+}
+
+.card[data-state="unavailable"] .card-countdown {
+  color: var(--text-muted);
+}
+
+.card[data-state="stale"] .card-countdown {
+  color: var(--accent-stale);
+}
+
+.card[data-state="live"] .card-countdown {
+  color: var(--accent-live);
+}
+
+/* Homepage Card Structure */
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.card-title {
+  font-size: 18px;
+  font-weight: 800;
+  margin: 0;
+}
+
+.card-countdown {
+  font-size: 28px;
+  font-weight: 900;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -.02em;
+  margin-bottom: 12px;
+}
+
+.card-countdown .unit {
+  font-size: 16px;
+  color: var(--text-muted);
+  font-weight: 600;
+  margin-left: 1px;
+  margin-right: 6px;
+}
+
+.card-meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: var(--text-muted);
+  font-size: 12px;
+}
+
 /* Responsive */
 @media (max-width: 600px) {
   .countdown-value {
@@ -521,5 +649,9 @@ footer p {
 
   .countdown-box {
     padding: 32px 20px;
+  }
+
+  .card-countdown {
+    font-size: 22px;
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -5,13 +5,13 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description"
-    content="Real-time countdowns for game events, patches, and resets. Track Fortnite, League of Legends, CS2, VALORANT, and more - automatically updated every 6 hours.">
-  <meta property="og:title" content="NextReset - Game Countdowns & Status Tracker">
-  <meta property="og:description" content="Real-time countdowns for game events, patches, and resets">
+    content="Live tracking of official game resets and updates — no predictions. Track Fortnite, League of Legends, CS2, VALORANT, and more.">
+  <meta property="og:title" content="NextReset - Live Game Reset Tracker">
+  <meta property="og:description" content="Live tracking of official game resets and updates — no predictions">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://nextreset.co">
   <meta property="og:image" content="https://nextreset.co/og.png">
-  <title>NextReset - Game Countdowns & Status</title>
+  <title>NextReset - Live Game Reset Tracker</title>
   <link rel="icon" type="image/png" href="/favicon.png">
   <link rel="apple-touch-icon" href="/favicon.png">
   <link rel="stylesheet" href="/assets/styles.css">
@@ -25,126 +25,137 @@
         <span class="dot"></span>
         NextReset
       </div>
+      <div class="trust-badges">
+        <span class="trust-badge">Official sources only</span>
+        <span class="trust-badge">Honest data</span>
+      </div>
     </div>
 
     <!-- Hero -->
     <div class="hero">
-      <h1 class="h1">Next resets & updates</h1>
-      <p class="sub">Countdowns for the biggest games. Always updated.</p>
+      <h1 class="h1">NextReset</h1>
+      <p class="sub">Live tracking of official game resets and updates — no predictions.</p>
     </div>
 
-    <!-- Ad Top -->
-    <div class="ad-slot ad-slot--top"></div>
-
     <!-- Game Grid -->
-    <div class="grid">
-      <a href="/fortnite/next-season/" class="card">
-        <div class="kicker">Battle Royale</div>
-        <h2 class="title">Fortnite</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Next Season
-          </span>
+    <div class="grid" id="game-grid">
+      <a href="/fortnite/next-season/" class="card" id="card-fortnite" data-game="fortnite" data-type="next-season"
+        data-state="loading" data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">Fortnite</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
 
-      <a href="/lol/next-patch/" class="card">
-        <div class="kicker">MOBA</div>
-        <h2 class="title">League of Legends</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Next Patch
-          </span>
+      <a href="/lol/next-patch/" class="card" id="card-lol" data-game="lol" data-type="next-patch" data-state="loading"
+        data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">League of Legends</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
 
-      <a href="/valorant/last-patch/" class="card">
-        <div class="kicker">Tactical Shooter</div>
-        <h2 class="title">VALORANT</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Last Patch
-          </span>
+      <a href="/valorant/last-patch/" class="card" id="card-valorant" data-game="valorant" data-type="last-patch"
+        data-state="loading" data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">VALORANT</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
 
-      <a href="/cs2/last-update/" class="card">
-        <div class="kicker">FPS</div>
-        <h2 class="title">Counter-Strike 2</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Last Update
-          </span>
+      <a href="/cs2/last-update/" class="card" id="card-cs2" data-game="cs2" data-type="last-update"
+        data-state="loading" data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">Counter-Strike 2</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
 
-      <a href="/minecraft/last-release/" class="card">
-        <div class="kicker">Sandbox</div>
-        <h2 class="title">Minecraft</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Last Release
-          </span>
+      <a href="/minecraft/last-release/" class="card" id="card-minecraft" data-game="minecraft" data-type="last-release"
+        data-state="loading" data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">Minecraft</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
 
-      <a href="/roblox/status/" class="card">
-        <div class="kicker">Platform</div>
-        <h2 class="title">Roblox</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Service Status
-          </span>
+      <a href="/roblox/status/" class="card" id="card-roblox" data-game="roblox" data-type="status" data-state="loading"
+        data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">Roblox</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
 
-      <a href="/gta/weekly-reset/" class="card">
-        <div class="kicker">Open World</div>
-        <h2 class="title">GTA Online</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Weekly Reset
-          </span>
+      <a href="/gta/weekly-reset/" class="card" id="card-gta" data-game="gta" data-type="weekly-reset"
+        data-state="loading" data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">GTA Online</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
 
-      <a href="/warzone/last-patch/" class="card">
-        <div class="kicker">Battle Royale</div>
-        <h2 class="title">Warzone</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Last Patch
-          </span>
+      <a href="/warzone/last-patch/" class="card" id="card-warzone" data-game="warzone" data-type="last-patch"
+        data-state="loading" data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">Warzone</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
 
-      <a href="/genshin/next-banner/" class="card">
-        <div class="kicker">RPG</div>
-        <h2 class="title">Genshin Impact</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Next Banner
-          </span>
+      <a href="/genshin/next-banner/" class="card" id="card-genshin" data-game="genshin" data-type="next-banner"
+        data-state="loading" data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">Genshin Impact</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
 
-      <a href="/pubg/last-patch/" class="card">
-        <div class="kicker">Battle Royale</div>
-        <h2 class="title">PUBG</h2>
-        <div class="meta">
-          <span class="pill">
-            <span class="mini"></span>
-            Last Patch
-          </span>
+      <a href="/pubg/last-patch/" class="card" id="card-pubg" data-game="pubg" data-type="last-patch"
+        data-state="loading" data-next-utc="">
+        <div class="card-header">
+          <h2 class="card-title">PUBG</h2>
+          <span class="badge badge-unavailable">--</span>
+        </div>
+        <div class="card-countdown">Loading...</div>
+        <div class="card-meta">
+          <span class="last-checked">--</span>
         </div>
       </a>
     </div>
@@ -155,6 +166,8 @@
       <p>Not affiliated with any game publishers. All trademarks belong to their respective owners.</p>
     </footer>
   </div>
+
+  <script src="/assets/app.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
- Refactor CSS variables to new naming (--bg-main, --accent-live, etc.)
- Add legacy variable mappings for safe migration
- Remove light mode, dark theme only
- Add status badge styles (LIVE/STALE/UNAVAILABLE)
- Update index.html with dynamic card structure
- Add trust badges in header
- Remove ad slot placeholder
- Add homepage JS initialization with parallel data fetching
- Implement 60-second countdown updates (recompute only, no refetch)
- Add state-driven card styling via data-state attribute